### PR TITLE
serverless.ymlのroleの書き方修正2

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -3,10 +3,11 @@
 service: avshare
 
 provider:
+  variableSyntax: "\\${{([ ~:a-zA-Z0-9._\\'\",\\-\\/\\(\\)]+?)}}" # notice the double quotes for yaml to ignore the escape characters!
   name: aws
   runtime: nodejs6.10
   stage: dev
-  region: ${env:AWS_REGION, 'ap-northeast-1'}
+  region: ${{env:AWS_REGION, 'ap-northeast-1'}}
   memorySize: 128
   timeout: 60
 
@@ -20,12 +21,12 @@ functions:
       - http: ANY /
       - http: 'ANY {proxy+}'
     environment:
-      MYNAME: ${env:MYNAME}
-      MYPASS: ${env:MYPASS}
+      MYNAME: ${{env:MYNAME}}
+      MYPASS: ${{env:MYPASS}}
       MY_FAVORITES_DOMAIN: d2ri4pj87do1tj.cloudfront.net
       OLD_PROGRAMS_DOMAIN: d1fbdzhz2ci06b.cloudfront.net
       CLOUDFRONT_KEY_PAIR_ID: APKAIZXOXRN6HZYYWLNQ
-      CLOUDFRONT_PRIVATE_KEY_STRING: ${env:CLOUDFRONT_PRIVATE_KEY_STRING}
+      CLOUDFRONT_PRIVATE_KEY_STRING: ${{env:CLOUDFRONT_PRIVATE_KEY_STRING}}
       BUCKET_NAME: jp-live-bruin-iwai-audio-video
     role: appRole
 
@@ -52,24 +53,12 @@ resources:
                   Action:
                     - logs:CreateLogStream
                   Resource:
-                    - 'Fn::Join':
-                      - ':'
-                      -
-                        - 'arn:aws:logs'
-                        - Ref: 'AWS::Region'
-                        - Ref: 'AWS::AccountId'
-                        - !Sub 'log-group:/aws/lambda/${AWS::StackName}-app:*'
+                    - Fn::Sub: arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${AWS::StackName}-app:*
                 - Effect: Allow # note that these rights are given in the default policy and are required if you want logs out of your lambda(s)
                   Action:
                     - logs:PutLogEvents
                   Resource:
-                    - 'Fn::Join':
-                      - ':'
-                      -
-                        - 'arn:aws:logs'
-                        - Ref: 'AWS::Region'
-                        - Ref: 'AWS::AccountId'
-                        - !Sub 'log-group:/aws/lambda/${AWS::StackName}-app:*:*'
+                    - Fn::Sub: arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${AWS::StackName}-app:*:*
           - PolicyName: s3access
             PolicyDocument:
               Version: '2012-10-17'


### PR DESCRIPTION
serverless.yml の中の変数参照 `${variable}` と CloudFormation のパラメータ参照 `${parameter}` が同じで、CloudFormation リソース記述の中のパラメータを serverless が自分の変数と取り違えてしまうのを防ぐため、serverless 変数参照は `${{variable}}` と記述するように修正。

また、serverless.yml の中では CloudFormation の組み込み関数の省略記法 `!Ref`, `!Sub` などがサポートされていないので、それぞれ `Ref`, `Fn::Sub` と記述するように修正。 