### PR TITLE
update lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -175,6 +175,13 @@
       "integrity": "sha1-ORD1ptDZD+wH8rTvirB/Pu+1Yl0=",
       "requires": {
         "lodash": "3.10.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        }
       }
     },
     "b64": {
@@ -1652,9 +1659,9 @@
       }
     },
     "lodash": {
-      "version": "3.10.1",
-      "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.includes": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "body-parser": "^1.18.2",
     "debug": "^3.1.0",
     "express": "^4.16.2",
+    "lodash": "^4.17.10",
     "moment": "^2.20.1",
     "serverless-http": "^1.5.3"
   },


### PR DESCRIPTION
aws-cloudfront-sign@2.2.0 が脆弱性のある lodash@3.10.1 に依存していて GitHub から vulnerability alert が来るので、明示的に lodash@latest をインストールする。