### PR TITLE
Node V8対応

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -5,11 +5,17 @@ service: avshare
 provider:
   variableSyntax: "\\${{([ ~:a-zA-Z0-9._\\'\",\\-\\/\\(\\)]+?)}}" # notice the double quotes for yaml to ignore the escape characters!
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs8.10
   stage: dev
   region: ${{env:AWS_REGION, 'ap-northeast-1'}}
   memorySize: 128
-  timeout: 60
+  timeout: 30
+  iamRoleStatements:
+    - Effect: "Allow"
+      Action:
+        - "s3:GetObject"
+      Resource:
+        - arn:aws:s3:::jp-live-bruin-iwai-audio-video/*
 
 plugins:
   - serverless-offline
@@ -28,43 +34,3 @@ functions:
       CLOUDFRONT_KEY_PAIR_ID: APKAIZXOXRN6HZYYWLNQ
       CLOUDFRONT_PRIVATE_KEY_STRING: ${{env:CLOUDFRONT_PRIVATE_KEY_STRING}}
       BUCKET_NAME: jp-live-bruin-iwai-audio-video
-    role: appRole
-
-resources:
-  Resources:
-    appRole:
-      Type: AWS::IAM::Role
-      Properties:
-        Path: /
-        AssumeRolePolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-            - Effect: Allow
-              Principal:
-                Service:
-                  - lambda.amazonaws.com
-              Action: sts:AssumeRole
-        Policies:
-          - PolicyName: lambdaDefault
-            PolicyDocument:
-              Version: '2012-10-17'
-              Statement:
-                - Effect: Allow # note that these rights are given in the default policy and are required if you want logs out of your lambda(s)
-                  Action:
-                    - logs:CreateLogStream
-                  Resource:
-                    - Fn::Sub: arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${AWS::StackName}-app:*
-                - Effect: Allow # note that these rights are given in the default policy and are required if you want logs out of your lambda(s)
-                  Action:
-                    - logs:PutLogEvents
-                  Resource:
-                    - Fn::Sub: arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${AWS::StackName}-app:*:*
-          - PolicyName: s3access
-            PolicyDocument:
-              Version: '2012-10-17'
-              Statement:
-                - Effect: "Allow"
-                  Action:
-                    - "s3:GetObject"
-                  Resource:
-                    - arn:aws:s3:::jp-live-bruin-iwai-audio-video/*


### PR DESCRIPTION
- Node V8対応
- タイムアウトは API Gateway のデフォルトに合わせて30秒に
- IAM Roleは serverless.yml の iamRoleStatements で簡便に指定するように修正