### PR TITLE
lodashをdependenciesから削除

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2787,7 +2787,8 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash.includes": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "body-parser": "^1.19.0",
     "debug": "^4.1.1",
     "express": "^4.17.1",
-    "lodash": "^4.17.11",
     "moment": "^2.24.0",
     "serverless-http": "^2.0.2"
   },


### PR DESCRIPTION
アプリでは直接参照していないので、 lodash を dependencies から削除する。